### PR TITLE
Replaced rdpcap() with PcapReader() for efficiency when parsing a Pcap

### DIFF
--- a/net-creds.py
+++ b/net-creds.py
@@ -968,11 +968,11 @@ def main(args):
     # Read packets from either pcap or interface
     if args.pcap:
         try:
-            pcap = rdpcap(args.pcap)
-        except Exception:
+            for pkt in PcapReader(args.pcap):
+                pkt_parser(pkt)
+        except IOError:
             exit('[-] Could not open %s' % args.pcap)
-        for pkt in pcap:
-            pkt_parser(pkt)
+
     else:
         # Check for root
         if geteuid():


### PR DESCRIPTION
heya!
This will replace the`rdpcap()` function with `PcapReader()`, the benefit is that `PcapReader()` reads a single packet at a time as supposed to `rdpcap()` which shoves the whole pcap into memory!

**HUGE** speed improvement!
