### PR TITLE
Fixed headers_to_dict such that HTTP responses are correctly parsed. …

### DIFF
--- a/net-creds.py
+++ b/net-creds.py
@@ -740,15 +740,13 @@ def headers_to_dict(header_lines):
     Convert the list of header lines into a dictionary
     '''
     headers = {}
-    # Incomprehensible list comprehension flattens list of headers
-    # that are each split at ': '
-    # http://stackoverflow.com/a/406296
-    headers_list = [x for line in header_lines for x in line.split(': ', 1)]
-    headers_dict = dict(zip(headers_list[0::2], headers_list[1::2]))
-    # Make the header key (like "Content-Length") lowercase
-    for header in headers_dict:
-        headers[header.lower()] = headers_dict[header]
-
+    for line in header_lines:
+        lineList=line.split(': ', 1)
+        key=lineList[0].lower()
+        if len(lineList)>1:
+                headers[key]=lineList[1]
+        else:
+                headers[key]=""
     return headers
 
 def parse_http_line(http_line, http_methods):
@@ -828,7 +826,7 @@ def parse_netntlm_chal(headers, chal_header, ack):
         msg2 = base64.decodestring(msg2)
         parse_ntlm_chal(ack, msg2)
 
-def parse_ntlm_chal(msg2, ack):
+def parse_ntlm_chal(ack, msg2):
     '''
     Parse server challenge
     '''


### PR DESCRIPTION
A issue was noted when using net-creds to parse HTTP traffic that were being sent to a proxy that required NTLM authentication. net-creds would be able to successfully parse and display the NETNTLMv2 response, however the the challenge would be replaced with the text CHALLENGE NOT FOUND. This problem was traced to two different issues:
1) The parse_http_line function would call the parse_ntlm_chal function. The arguments for this call was swapped around.
2)The headers_to_dict function incorrectly parsed all HTTP responses. The HTTP line, e.g. HTTP 200 OK, does not contain the ": " substring. This will cause the HTTP line to be incorrectly matched with the next header. This issue cascades, causing an incorrect matching of all header names and their values in the header dictionary.  By rewriting the function, and preventing lines without the ": " substring from being assigned to another header, it was possible to fix this issue, such that HTTP response are correctly parsed.

Using this version, one can correctly parse NETNTLMv2 challenge/responses sent in HTTP/Proxy authentication, thereby fixing the CHALLENGE NOT FOUND issue.