### PR TITLE
parse_ntlm_chal definition fix

### DIFF
--- a/net-creds.py
+++ b/net-creds.py
@@ -824,9 +824,9 @@ def parse_netntlm_chal(headers, chal_header, ack):
         except IndexError:
             return
         msg2 = base64.decodestring(msg2)
-        parse_ntlm_chal(ack, msg2)
+        parse_ntlm_chal(msg2, ack)
 
-def parse_ntlm_chal(ack, msg2):
+def parse_ntlm_chal(msg2, ack):
     '''
     Parse server challenge
     '''


### PR DESCRIPTION
The previous commit modified the function prototype of parse_ntlm_chal(msg2, ack) to parse_ntlm_chal(ack, msg2). While this fixed the issue with parse_netntlm_chal incorrectly calling parse_ntlm_chal, it created a new bug in other_parser (line 621), which now calls parse_ntlm_chal incorrectly. This commit reverts back to the original function prototype, and modifies the incorrect call to parse_ntlm_chal within parse_netntlm_chal instead.