### PR TITLE
Ignore case on Negotiate

### DIFF
--- a/net-creds.py
+++ b/net-creds.py
@@ -822,7 +822,7 @@ def parse_netntlm_chal(headers, chal_header, ack):
         return
     header_val2 = header_val2.split(' ', 1)
     # The header value can either start with NTLM or Negotiate
-    if header_val2[0] == 'NTLM' or header_val2[0] == 'Negotiate':
+    if header_val2[0] == 'NTLM' or header_val2[0].lower() == 'negotiate':
         try:
             msg2 = header_val2[1]
         except IndexError:


### PR DESCRIPTION
Hi,
Symantec BlueCoat proxies respond with NEGOTIATE instead of Negotiate (see https://origin-symwisedownload.symantec.com/resources/webguides/proxysg/security_first_steps/Content/Solutions/Authentication/IWA/IWA_verify_Kerberos_auth_ta.htm for example).

So it's better to lowercase the header value. Without it we get the CHALLENGE NOT FOUND error.